### PR TITLE
Support arguments in the testsuite

### DIFF
--- a/src/easyCurlTest.py
+++ b/src/easyCurlTest.py
@@ -3,9 +3,10 @@
 import clsRest as r
 import yaml
 
-LABEL_TESTSUITE = 'EASYCURL_TESTSUITE'
 EXT_PY   = 'py'
 EXT_YAML = 'yaml'
+BRAKET_LEFT = '['
+BRAKET_RIGHT = ']'
 
 def importYaml(yamlName):
     with open(yamlName, 'r') as f: doc = yaml.safe_load(f.read())
@@ -15,13 +16,25 @@ def createTs(tsDict):
     for tsId, tsTestCaseList in tsDict.iteritems():
         return r.TestSuite(tsId, tsTestCaseList)
 
+def parserTsArgs(tsFile):
+    tsArgs = None
+    tsFileName = tsFile
+    posLeft = tsFile.find(BRAKET_LEFT)
+    posRight = tsFile.find(BRAKET_RIGHT)
+    if posLeft >= 0 and posRight >= 0:
+        tsArgs = tsFile[posLeft+1 : posRight]
+        tsFileName = tsFile[:posLeft]
+    tsFileExt = tsFileName.split('.')[-1]
+    tsFilePrefix = '.'.join(tsFileName.split('.')[:-1])
+    return tsFileName, tsFilePrefix, tsFileExt, tsArgs
+
 def genTsFromFile(tsFile):
-    tsFileExt = tsFile.split('.')[-1]
-    tsFileName = '.'.join(tsFile.split('.')[:-1])
+    tsFileName, tsFilePrefix, tsFileExt, tsArgs = parserTsArgs(tsFile)
     if tsFileExt == EXT_PY:
-        tsImportModule = __import__(tsFileName, globals(), locals(), [LABEL_TESTSUITE], -1)
-        return createTs(tsImportModule.EASYCURL_TESTSUITE)
+        tsImportModule = __import__(tsFilePrefix, globals(), locals(), [], -1)
+        tsImportModule.generateTs(tsArgs)
+        return createTs(tsImportModule.generateTs(tsArgs))
     elif tsFileExt == EXT_YAML:
-        return createTs(importYaml(tsFile))
+        return createTs(importYaml(tsFileName))
     else:
         return None

--- a/src/easyCurlTest.py
+++ b/src/easyCurlTest.py
@@ -32,7 +32,6 @@ def genTsFromFile(tsFile):
     tsFileName, tsFilePrefix, tsFileExt, tsArgs = parserTsArgs(tsFile)
     if tsFileExt == EXT_PY:
         tsImportModule = __import__(tsFilePrefix, globals(), locals(), [], -1)
-        tsImportModule.generateTs(tsArgs)
         return createTs(tsImportModule.generateTs(tsArgs))
     elif tsFileExt == EXT_YAML:
         return createTs(importYaml(tsFileName))


### PR DESCRIPTION
If the test suite type is python, sometimes I also need to add the arguments for different configurations.