### PR TITLE
Support any METHOD in rest request

### DIFF
--- a/src/clsRest.py
+++ b/src/clsRest.py
@@ -39,6 +39,9 @@ class Request:
     def getBody(self):
         return self.body
 
+    def getMethod(self):
+        return self.method
+
     def __str__(self):
         strStartTime = '(' + str(self.startTime) + ')' if self.startTime != None else ''
         return '>>>> REST REQUEST SEND: ' + strStartTime + '\n' + self.method + ' ' + \
@@ -59,7 +62,7 @@ class Response:
         return self.statusCode
 
     def getDuration(self):
-        return self.endTime - self.startTime
+        return self.endTime - self.startTime if self.endTime != None and self.startTime != None else 0
 
     def getStartTime(self):
         return self.startTime
@@ -68,7 +71,7 @@ class Response:
         strEndTime = '(' + str(self.endTime) + ')' if self.endTime != None else ''
         return '<<<< REST RESPONSE RECEIVE: ' + strEndTime + '\n    (LATENCY: ' + \
                str(self.getDuration()) + ')\n' + \
-               self.headers + '\n' + self.body + '\n'
+               str(self.headers) + '\n' + str(self.body) + '\n'
 
 class Control:
     def getDefaultOpts(self):

--- a/src/easyCurl.py
+++ b/src/easyCurl.py
@@ -28,8 +28,8 @@ def runCurl(requestObj):
     responseBody = BytesIO()
     responseCode, responseHeaderStr, responseBodyStr = None, None, None
 
-    if optCurlMethods.get(method, None) != None:
-        c = setOptCurl(setOptCurl(pycurl.Curl(), optCurlMethods['COMMON']), optCurlMethods[method])
+    cType = method if optCurlMethods.get(method, None) != None else 'OTHERS'
+    c = setOptCurl(setOptCurl(pycurl.Curl(), optCurlMethods['COMMON']), optCurlMethods[cType])
 
     c.setopt(c.URL, url)
     c.setopt(c.HTTPHEADER, requestHeaders)
@@ -143,6 +143,7 @@ if(__name__ == '__main__'):
                      restCase.setPId(rcPId)
 
                      requestBodyStr = restCase.getRequest().getBody()
+                     method = restCase.getRequest().getMethod()
                      restCase.setResponse(Response(runCurl(restCase.getRequest().getProperty())))
                      restCase.getRequest().setStartTime(restCase.getResponse().getStartTime())
 

--- a/src/easyCurlConfig.py
+++ b/src/easyCurlConfig.py
@@ -11,7 +11,12 @@ optCurlMethods = {'COMMON': [('pycurl.TIMEOUT', 'int', '10'),
                   'PATCH' : [('pycurl.POSTFIELDS', 'str', 'requestBodyStr'),
                              ('pycurl.CUSTOMREQUEST', 'raw', 'PATCH'),
                              ('pycurl.INFILESIZE', 'int', 'len(requestBodyStr)')],
-                  'DELETE': [('pycurl.CUSTOMREQUEST', 'raw', 'DELETE')]
+                  'DELETE': [('pycurl.CUSTOMREQUEST', 'raw', 'DELETE'),
+                             ('pycurl.POSTFIELDS', 'str', 'requestBodyStr'),
+                             ('pycurl.POSTFIELDSIZE', 'int', 'len(requestBodyStr)')],
+                  'OTHERS': [('pycurl.CUSTOMREQUEST', 'str', 'method'),
+                             ('pycurl.POSTFIELDS', 'str', 'requestBodyStr'),
+                             ('pycurl.POSTFIELDSIZE', 'int', 'len(requestBodyStr)')]
 }
 
 # LOG FILE NAME


### PR DESCRIPTION
The new feature to support any METHOD is added. In some negative test cases, the any free-text METHOD type is used to sent to REST server, so the easyCurl should not have any limitation.
By the way, one small buy found in the clsRest has been fixed.